### PR TITLE
HotFix-SapOnline check

### DIFF
--- a/src/Sap/Infrastructure/SoapAdapter.php
+++ b/src/Sap/Infrastructure/SoapAdapter.php
@@ -9,15 +9,17 @@ class SoapAdapter implements AdapterInterface
 	private $client;
 
 	public function __construct(
-			$wsdl, $login, $password, $soapVersion
+			$wsdl, $login, $password, $soapVersion, $sapOnline
 	){
-		$this->client = new SoapClient($wsdl, 
-		[
-			'login'          => $login,
-			'password'       => $password,
-			'soap_version'   => $soapVersion,
-			'cache_wsdl'     => WSDL_CACHE_DISK
-		]);
+	    if($sapOnline){
+    		$this->client = new SoapClient($wsdl, 
+    		[
+    			'login'          => $login,
+    			'password'       => $password,
+    			'soap_version'   => $soapVersion,
+    			'cache_wsdl'     => WSDL_CACHE_DISK
+    		]);
+	   }
 	}
 	
 	/**

--- a/src/Sap/Infrastructure/SoapAdapter.php
+++ b/src/Sap/Infrastructure/SoapAdapter.php
@@ -7,11 +7,14 @@ class SoapAdapter implements AdapterInterface
 {
 	/** @var SoapClient */
 	private $client;
+	
+	/** @var string */
+	private $error;
 
 	public function __construct(
-			$wsdl, $login, $password, $soapVersion, $sapOnline
-	){
-	    if($sapOnline){
+			$wsdl, $login, $password, $soapVersion
+	){	    
+	    try{
     		$this->client = new SoapClient($wsdl, 
     		[
     			'login'          => $login,
@@ -19,7 +22,9 @@ class SoapAdapter implements AdapterInterface
     			'soap_version'   => $soapVersion,
     			'cache_wsdl'     => WSDL_CACHE_DISK
     		]);
-	   }
+	    } catch (\Exception $e) {
+	        $this->error = $e->getMessage();
+	    }
 	}
 	
 	/**
@@ -28,7 +33,7 @@ class SoapAdapter implements AdapterInterface
 	 */
 	public function getResponse($methodName, array $arguments) 
 	{
-		return $this->client->$methodName($this->prepareArguments($arguments));
+	    return empty($this->error) ? $this->client->$methodName($this->prepareArguments($arguments)) : new \stdClass();
 	}
 
 	/**


### PR DESCRIPTION
-removed sap online check
-added try catch block when creating new SoapClient object
-added property error to the SoapAdapter
-added check if there was error when creating new SoapClient object
(returns empty stdclass if there was an error)